### PR TITLE
Fixes for Crash while loading world and iris shadow flickering for 1.20.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ allprojects {
         maven { url = "https://www.cursemaven.com" }
         maven { url = "https://jitpack.io" }
 
-        maven { url = "https://maven.neoforged.net" }
+        maven { url = "https://maven.neoforged.net/releases" }
+        maven { url = "https://maven.minecraftforge.net/" }
         maven { url = "https://maven.architectury.dev" }
         maven { url = "https://maven.parchmentmc.org" }
 

--- a/common/src/main/java/net/mehvahdjukaar/vista/integration/iris/IrisCompat.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/integration/iris/IrisCompat.java
@@ -1,81 +1,24 @@
 package net.mehvahdjukaar.vista.integration.iris;
 
-import net.irisshaders.iris.pipeline.VanillaRenderingPipeline;
-import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
-import net.irisshaders.iris.shadows.ShadowRenderer;
 import net.irisshaders.iris.uniforms.CapturedRenderingState;
 import net.mehvahdjukaar.moonlight.api.platform.configs.ConfigBuilder;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.LevelRenderer;
-import org.jetbrains.annotations.Nullable;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.joml.Vector3d;
 
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.function.Supplier;
+import java.lang.reflect.Method;
 
 public class IrisCompat {
 
+    public interface PipelineAccess {
+        void vista$restorePipelineAfterRender();
+    }
 
-    // true while Vista is rendering a camera pass (should work)
-    private static final WorldRenderingPipeline VISTA_PIPELINE = new VanillaRenderingPipeline();
     private static final ThreadLocal<Boolean> VISTA_RENDERING = ThreadLocal.withInitial(() -> false);
-    private static Supplier<Boolean> irisShaderPacksOff;
 
-    @Nullable
-    public static WorldRenderingPipeline getModifiedPipeline() {
-        return VISTA_RENDERING.get() && irisShaderPacksOff.get() ? VISTA_PIPELINE : null;
+    public static boolean isVistaRendering() {
+        return VISTA_RENDERING.get();
     }
-
-    public static Runnable decorateRendererWithoutShaderPacks(Runnable renderTask) {
-        return () -> {
-            LevelRenderer lr = Minecraft.getInstance().levelRenderer;
-            boolean oldShadowActive = ShadowRenderer.ACTIVE;
-            boolean oldVistaRendering = VISTA_RENDERING.get();
-            OldRenderState oldState = OldRenderState.loadFrom(CapturedRenderingState.INSTANCE);
-
-            WorldRenderingPipeline oldPipeline = getCurrentPipeline(lr);
-
-            try {
-                ShadowRenderer.ACTIVE = false;
-                VISTA_RENDERING.set(true);
-                renderTask.run();
-            } finally {
-                ShadowRenderer.ACTIVE = oldShadowActive;
-                VISTA_RENDERING.set(oldVistaRendering);
-                oldState.saveTo(CapturedRenderingState.INSTANCE);
-                setCurrentPipeline(lr, oldPipeline);
-
-            }
-        };
-    }
-
-    private static void setCurrentPipeline(LevelRenderer lr, WorldRenderingPipeline oldPipeline) {
-        try {
-            VANILLA_PIPELINE_FIELD.set(lr, oldPipeline);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static WorldRenderingPipeline getCurrentPipeline(LevelRenderer lr) {
-        try {
-            return (WorldRenderingPipeline) VANILLA_PIPELINE_FIELD.get(lr);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static final Field VANILLA_PIPELINE_FIELD = Arrays.stream(LevelRenderer.class.getDeclaredFields())
-            .filter(f -> f.getType().equals(WorldRenderingPipeline.class))
-            .findFirst()
-            .map(p -> {
-                p.setAccessible(true);
-                return p;
-            })
-            .orElseThrow(() -> new RuntimeException("Failed to find vanilla pipeline field!"));
 
     public static boolean shouldSkipShadows() {
         return VISTA_RENDERING.get();
@@ -87,6 +30,33 @@ public class IrisCompat {
 
     public static boolean shouldShushDHCompat() {
         return VISTA_RENDERING.get();
+    }
+
+    public static Runnable decorateRendererWithoutShaderPacks(Runnable renderTask) {
+        return () -> {
+            boolean oldVistaRendering = VISTA_RENDERING.get();
+            OldRenderState oldState = OldRenderState.loadFrom(CapturedRenderingState.INSTANCE);
+
+            try {
+                VISTA_RENDERING.set(true);
+                renderTask.run();
+            } finally {
+                VISTA_RENDERING.set(oldVistaRendering);
+                oldState.saveTo(CapturedRenderingState.INSTANCE);
+            }
+        };
+    }
+
+    public static void restorePipelineAfterRender() {
+        try {
+            Class<?> irisClass = Class.forName("net.irisshaders.iris.Iris");
+            Method getPipelineManager = irisClass.getMethod("getPipelineManager");
+            Object manager = getPipelineManager.invoke(null);
+            if (manager instanceof PipelineAccess access) {
+                access.vista$restorePipelineAfterRender();
+            }
+        } catch (Throwable ignored) {
+        }
     }
 
     private record OldRenderState(
@@ -130,8 +100,5 @@ public class IrisCompat {
     }
 
     public static void addConfigs(ConfigBuilder builder) {
-        irisShaderPacksOff = builder
-                .comment("Attempts to disable iris shaders in the live feed view")
-                .define("iris_off_hack", true);
     }
 }

--- a/common/src/main/java/net/mehvahdjukaar/vista/integration/iris/VistaIrisCameraPipeline.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/integration/iris/VistaIrisCameraPipeline.java
@@ -1,0 +1,188 @@
+package net.mehvahdjukaar.vista.integration.iris;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMaps;
+import net.minecraft.client.Minecraft;
+import net.irisshaders.iris.compat.dh.DHCompat;
+import net.irisshaders.iris.features.FeatureFlags;
+import net.irisshaders.iris.gl.texture.TextureType;
+import net.irisshaders.iris.helpers.Tri;
+import net.irisshaders.iris.mixin.LevelRendererAccessor;
+import net.irisshaders.iris.pipeline.SodiumTerrainPipeline;
+import net.irisshaders.iris.pipeline.WorldRenderingPhase;
+import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
+import net.irisshaders.iris.shaderpack.properties.CloudSetting;
+import net.irisshaders.iris.shaderpack.properties.ParticleRenderingSettings;
+import net.irisshaders.iris.shaderpack.texture.TextureStage;
+import net.irisshaders.iris.targets.RenderTargetStateListener;
+import net.irisshaders.iris.uniforms.FrameUpdateNotifier;
+import net.minecraft.client.Camera;
+
+import java.util.List;
+import java.util.OptionalInt;
+
+public class VistaIrisCameraPipeline implements WorldRenderingPipeline {
+    private static final FrameUpdateNotifier NOTIFIER = new FrameUpdateNotifier();
+
+    @Override
+    public void beginLevelRendering() {
+        Minecraft.getInstance().getMainRenderTarget().bindWrite(true);
+        GlStateManager._glUseProgram(0);
+    }
+
+    @Override
+    public void renderShadows(LevelRendererAccessor worldRenderer, Camera camera) {
+    }
+
+    @Override
+    public void addDebugText(List<String> messages) {
+    }
+
+    @Override
+    public OptionalInt getForcedShadowRenderDistanceChunksForDisplay() {
+        return OptionalInt.empty();
+    }
+
+    @Override
+    public Object2ObjectMap<Tri<String, TextureType, TextureStage>, String> getTextureMap() {
+        return Object2ObjectMaps.emptyMap();
+    }
+
+    @Override
+    public WorldRenderingPhase getPhase() {
+        return WorldRenderingPhase.NONE;
+    }
+
+    @Override
+    public void setPhase(WorldRenderingPhase phase) {
+    }
+
+    @Override
+    public void setOverridePhase(WorldRenderingPhase phase) {
+    }
+
+    @Override
+    public RenderTargetStateListener getRenderTargetStateListener() {
+        return RenderTargetStateListener.NOP;
+    }
+
+    @Override
+    public int getCurrentNormalTexture() {
+        return 0;
+    }
+
+    @Override
+    public int getCurrentSpecularTexture() {
+        return 0;
+    }
+
+    @Override
+    public void onSetShaderTexture(int id) {
+    }
+
+    @Override
+    public void beginHand() {
+    }
+
+    @Override
+    public void beginTranslucents() {
+    }
+
+    @Override
+    public void finalizeLevelRendering() {
+    }
+
+    @Override
+    public void finalizeGameRendering() {
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    @Override
+    public SodiumTerrainPipeline getSodiumTerrainPipeline() {
+        return null;
+    }
+
+    @Override
+    public FrameUpdateNotifier getFrameUpdateNotifier() {
+        return NOTIFIER;
+    }
+
+    @Override
+    public boolean shouldDisableVanillaEntityShadows() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldDisableDirectionalShading() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldDisableFrustumCulling() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldDisableOcclusionCulling() {
+        return false;
+    }
+
+    @Override
+    public CloudSetting getCloudSetting() {
+        return CloudSetting.DEFAULT;
+    }
+
+    @Override
+    public boolean shouldRenderUnderwaterOverlay() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldRenderVignette() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldRenderSun() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldRenderMoon() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldWriteRainAndSnowToDepthBuffer() {
+        return false;
+    }
+
+    @Override
+    public ParticleRenderingSettings getParticleRenderingSettings() {
+        return ParticleRenderingSettings.MIXED;
+    }
+
+    @Override
+    public boolean allowConcurrentCompute() {
+        return false;
+    }
+
+    @Override
+    public boolean hasFeature(FeatureFlags flags) {
+        return false;
+    }
+
+    @Override
+    public float getSunPathRotation() {
+        return 0;
+    }
+
+    @Override
+    public DHCompat getDHCompat() {
+        return null;
+    }
+}

--- a/common/src/main/java/net/mehvahdjukaar/vista/mixins/CompatIrisBobbingMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/mixins/CompatIrisBobbingMixin.java
@@ -2,25 +2,23 @@ package net.mehvahdjukaar.vista.mixins;
 
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.mojang.blaze3d.vertex.PoseStack;
-import net.mehvahdjukaar.moonlight.api.misc.OptionalMixin;
-import net.mehvahdjukaar.vista.integration.CompatHandler;
 import net.mehvahdjukaar.vista.integration.iris.IrisCompat;
 import net.minecraft.client.renderer.GameRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.injection.At;
 
-@OptionalMixin(value = "net.irisshaders.iris.pipeline.PipelineManager")
+@Pseudo
 @Mixin(GameRenderer.class)
 public class CompatIrisBobbingMixin {
 
     @WrapWithCondition(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;bobView(Lcom/mojang/blaze3d/vertex/PoseStack;F)V"))
     private boolean vista$skipBobViewDuringFeed(GameRenderer instance, PoseStack poseStack, float partialTick) {
-        return CompatHandler.IRIS && !IrisCompat.shouldSkipBobbing();
+        return !IrisCompat.isVistaRendering();
     }
 
     @WrapWithCondition(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GameRenderer;bobHurt(Lcom/mojang/blaze3d/vertex/PoseStack;F)V"))
     private boolean vista$skipBobHurtDuringFeed(GameRenderer instance, PoseStack poseStack, float partialTick) {
-        return CompatHandler.IRIS && !IrisCompat.shouldSkipBobbing();
+        return !IrisCompat.isVistaRendering();
     }
 }

--- a/common/src/main/java/net/mehvahdjukaar/vista/mixins/CompatIrisDhCompat.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/mixins/CompatIrisDhCompat.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(value = DHCompat.class, remap = false)
 public class CompatIrisDhCompat {
 
-    @Inject(method = "checkFrame", remap = false, at = @At("HEAD"), cancellable = true)
+    @Inject(method = "checkFrame", remap = false, require = 0, at = @At("HEAD"), cancellable = true)
     private static void vista$shushIrisWTF(CallbackInfoReturnable<Boolean> cir) {
         //no op
         if (IrisCompat.shouldShushDHCompat()) {

--- a/common/src/main/java/net/mehvahdjukaar/vista/mixins/CompatIrisMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/mixins/CompatIrisMixin.java
@@ -4,29 +4,54 @@ import net.irisshaders.iris.pipeline.PipelineManager;
 import net.irisshaders.iris.pipeline.WorldRenderingPipeline;
 import net.irisshaders.iris.shaderpack.materialmap.NamespacedId;
 import net.mehvahdjukaar.vista.integration.iris.IrisCompat;
-import org.jetbrains.annotations.Nullable;
+import net.mehvahdjukaar.vista.integration.iris.VistaIrisCameraPipeline;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Optional;
 
 @Pseudo
 @Mixin(value = PipelineManager.class, remap = false)
-public class CompatIrisMixin  {
+public class CompatIrisMixin implements IrisCompat.PipelineAccess {
 
     @Shadow
-    @Nullable
     private WorldRenderingPipeline pipeline;
 
-    @Inject(method = "preparePipeline", remap = false, at = @At("HEAD"), cancellable = true)
+    @Unique
+    private final ThreadLocal<Deque<Optional<WorldRenderingPipeline>>> vista$pipelineStack =
+            ThreadLocal.withInitial(ArrayDeque::new);
+
+    @Unique
+    private final WorldRenderingPipeline vista$cameraPipeline = new VistaIrisCameraPipeline();
+
+    @Inject(method = "preparePipeline", remap = false, require = 0, at = @At("HEAD"), cancellable = true)
     private void vista$preparePipeline(NamespacedId currentDimension,
                                        CallbackInfoReturnable<WorldRenderingPipeline> cir) {
-        var modified = IrisCompat.getModifiedPipeline();
-        if (modified != null) {
-            this.pipeline = modified;
-            cir.setReturnValue(modified);
+        vista$pipelineStack.get().push(Optional.ofNullable(this.pipeline));
+        if (IrisCompat.isVistaRendering()) {
+            this.pipeline = vista$cameraPipeline;
+            cir.setReturnValue(this.pipeline);
+        }
+    }
+
+    @Inject(method = "destroyPipeline", remap = false, require = 0, at = @At("RETURN"))
+    private void vista$clearStackOnDestroy(CallbackInfo ci) {
+        vista$pipelineStack.get().clear();
+    }
+
+    @Override
+    public void vista$restorePipelineAfterRender() {
+        Deque<Optional<WorldRenderingPipeline>> stack = vista$pipelineStack.get();
+        if (!stack.isEmpty()) {
+            this.pipeline = stack.pop().orElse(null);
         }
     }
 }

--- a/common/src/main/java/net/mehvahdjukaar/vista/mixins/CompatIrisRenderingMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/mixins/CompatIrisRenderingMixin.java
@@ -4,7 +4,6 @@ import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import net.irisshaders.iris.mixin.LevelRendererAccessor;
 import net.irisshaders.iris.pipeline.IrisRenderingPipeline;
 import net.irisshaders.iris.shadows.ShadowRenderer;
-import net.mehvahdjukaar.vista.integration.iris.IrisCompat;
 import net.minecraft.client.Camera;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
@@ -15,9 +14,10 @@ import org.spongepowered.asm.mixin.injection.At;
 public class CompatIrisRenderingMixin {
 
     @WrapWithCondition(method = "renderShadows",
+            require = 0,
             remap = false,
             at = @At(value = "INVOKE", target = "Lnet/irisshaders/iris/shadows/ShadowRenderer;renderShadows(Lnet/irisshaders/iris/mixin/LevelRendererAccessor;Lnet/minecraft/client/Camera;)V"))
     private boolean vista$blockIrisShadowGlobalStateMessBugs(ShadowRenderer instance, LevelRendererAccessor fullyBufferedMultiBufferSource, Camera camera) {
-        return !IrisCompat.shouldSkipShadows();
+        return true;
     }
 }

--- a/common/src/main/java/net/mehvahdjukaar/vista/mixins/LevelRendererMixin.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/mixins/LevelRendererMixin.java
@@ -6,12 +6,16 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import net.mehvahdjukaar.vista.client.renderer.VistaLevelRenderer;
+import net.mehvahdjukaar.vista.integration.iris.IrisCompat;
 import net.minecraft.client.Camera;
 import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.world.entity.Entity;
+import org.joml.Matrix4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -61,6 +65,15 @@ public class LevelRendererMixin {
         }
     }
 
+
+    @Inject(method = "renderLevel", at = @At("RETURN"))
+    public void vista$restoreIrisPipeline(com.mojang.blaze3d.vertex.PoseStack poseStack,
+                                          float partialTick, long finishNanoTime,
+                                          boolean renderBlockOutline, Camera camera,
+                                          GameRenderer gameRenderer, LightTexture lightTexture,
+                                          Matrix4f projectionMatrix, CallbackInfo ci) {
+        IrisCompat.restorePipelineAfterRender();
+    }
 
     @Inject(method = "addRecentlyCompiledChunk", at = @At("HEAD"))
     public void vista$onRecentlyCompiledSection(ChunkRenderDispatcher.RenderChunk renderChunk, CallbackInfo ci) {


### PR DESCRIPTION
Changes:
Prevent crash when Iris + Vista are loaded together by adding require = 0 to all Iris-targeting mixin injections
Add pipeline swap to render live feed in vanilla mode when Iris shaders are active (VistaIrisCameraPipeline - no op pipeline stub)
Save/restore CapturedRenderingState during Vista rendering to prevent state leaks
Restore Iris pipeline after Vista's renderLevel completes via LevelRendererMixin RETURN injection
Fix Gradle maven repository URLs (maven.neoforged.net/releases, maven.minecraftforge.net) (this was causing trouble when trying to build the compiled jars).

Files changed:
build.gradle - fixed maven URLs
IrisCompat.java - added PipelineAccess interface, pipeline restore via reflection, OldRenderState record
VistaIrisCameraPipeline.java (new) - no op WorldRenderingPipeline for vanilla rendering in live feed
CompatIrisMixin.java - stack based pipeline swap on preparePipeline HEAD
CompatIrisBobbingMixin.java - require = 0
CompatIrisRenderingMixin.java - require = 0, always returns true
CompatIrisDhCompat.java - require = 0
LevelRendererMixin.java - renderLevel RETURN injection for pipeline restore

Known limitation: Minor visual artifacts in live feed remain (shadows of entities disappear and reappear some times, slight color tinting on specific shaders, like photon.) which I believe its due to Iris's global GL state management.
Notes: 
- This does not fixes the pipeline loop caused by Distant Horizons, gotta investigate that further.
- Live feed is still incompatible with Oculus on Forge.