### PR TITLE
fix: defer broadcast linking when server levels are not yet bound

### DIFF
--- a/common/src/main/java/net/mehvahdjukaar/vista/common/broadcast/BroadcastManager.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/common/broadcast/BroadcastManager.java
@@ -190,4 +190,22 @@ public final class BroadcastManager extends WorldSavedData {
         return VistaMod.VIEWFINDER_CONNECTION.getData(level);
     }
 
+    /**
+     * Returns the manager only when the server's levels are fully constructed and their saved-data
+     * storage is bound, null otherwise. During server boot some mods (e.g. Sable) force-load
+     * sub-level chunks from inside the {@code ServerLevel} constructor, when
+     * {@code server.overworld()} and its data storage are not available yet; linking must be
+     * deferred in that window or {@code WorldSavedDataType#getData} throws a NullPointerException.
+     */
+    @Nullable
+    public static BroadcastManager getInstanceIfReady(Level level) {
+        if (level instanceof ServerLevel sl) {
+            ServerLevel target = sl.getServer().overworld();
+            if (target != null && target.getDataStorage() != null) {
+                return getInstance(level);
+            }
+        }
+        return null;
+    }
+
 }

--- a/common/src/main/java/net/mehvahdjukaar/vista/common/cassette/IBroadcastSource.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/common/cassette/IBroadcastSource.java
@@ -19,6 +19,20 @@ public interface IBroadcastSource {
         }
     }
 
+    /**
+     * Links the feed immediately when the level's saved-data storage is available, returning false
+     * when the link was deferred (level still under construction during early chunk loading).
+     * Callers should retry later, e.g. from their tick method. See {@link BroadcastManager#getInstanceIfReady}.
+     */
+    default boolean linkFeedIfReady(Level level, IBroadcastLocation location) {
+        BroadcastManager manager = BroadcastManager.getInstanceIfReady(level);
+        if (manager != null) {
+            manager.linkFeed(this.getBroadcastUUID(), location);
+            return true;
+        }
+        return false;
+    }
+
     default void removeLink(Level level) {
         if (level instanceof ServerLevel sl) {
             BroadcastManager.getInstance(sl)

--- a/common/src/main/java/net/mehvahdjukaar/vista/common/view_finder/ViewFinderBlockEntity.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/common/view_finder/ViewFinderBlockEntity.java
@@ -61,6 +61,7 @@ public class ViewFinderBlockEntity extends ItemDisplayTile implements IOneUserIn
 
     private final LiveFeedVideoSource videoSource;
     private UUID myUUID;
+    private boolean linkDeferred = false; //true when setLevel ran before the server levels were fully bound
     private int powerLevelWantedZoom = 0; //0 means HOLD, ignore wanted level
     private int zoom = 1; //from 1 to 44
     private boolean locked = false;
@@ -77,6 +78,9 @@ public class ViewFinderBlockEntity extends ItemDisplayTile implements IOneUserIn
 
     public static void tick(Level level, BlockPos pos, BlockState state, ViewFinderBlockEntity tile) {
         tile.orientation.tick();
+        if (tile.linkDeferred) {
+            tile.linkDeferred = !tile.linkFeedIfReady(level, LevelBEBroadcastLocation.of(tile));
+        }
         if (tile.powerLevelWantedZoom > 0 && tile.zoom != tile.powerLevelWantedZoom && tile.getCurrentUser() == null) {
             int zoomDiff = tile.powerLevelWantedZoom - tile.zoom;
             int zoomStep = Mth.clamp(zoomDiff, -1, 1);
@@ -87,7 +91,8 @@ public class ViewFinderBlockEntity extends ItemDisplayTile implements IOneUserIn
     @Override
     public void setLevel(Level level) {
         super.setLevel(level);
-        this.ensureLinked(level, LevelBEBroadcastLocation.of(this));
+        this.linkDeferred = level instanceof ServerLevel &&
+                !this.linkFeedIfReady(level, LevelBEBroadcastLocation.of(this));
     }
 
 

--- a/common/src/main/java/net/mehvahdjukaar/vista/common/wave_gate/WaveGateBlock.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/common/wave_gate/WaveGateBlock.java
@@ -23,6 +23,8 @@ import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -97,6 +99,12 @@ public class WaveGateBlock extends WaterBlock implements EntityBlock {
     @Override
     public @Nullable BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
         return new WaveGateBlockEntity(pos, state);
+    }
+
+    @Nullable
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level pLevel, BlockState pState, BlockEntityType<T> pBlockEntityType) {
+        return Utils.getTicker(pBlockEntityType, VistaMod.WAVE_GATE_TILE.get(), WaveGateBlockEntity::tick);
     }
 
     @Override

--- a/common/src/main/java/net/mehvahdjukaar/vista/common/wave_gate/WaveGateBlockEntity.java
+++ b/common/src/main/java/net/mehvahdjukaar/vista/common/wave_gate/WaveGateBlockEntity.java
@@ -18,6 +18,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -33,6 +34,7 @@ public class WaveGateBlockEntity extends BlockEntity implements IScreenProvider,
 
     private String url = "";
     private UUID myUUID;
+    private boolean linkDeferred = false; //true when setLevel ran before the server levels were fully bound
     private IVideoSource videoSource = IVideoSource.EMPTY;
 
     public WaveGateBlockEntity(BlockPos pos, BlockState state) {
@@ -63,7 +65,14 @@ public class WaveGateBlockEntity extends BlockEntity implements IScreenProvider,
     @Override
     public void setLevel(Level level) {
         super.setLevel(level);
-        this.ensureLinked(level, LevelBEBroadcastLocation.of(this));
+        this.linkDeferred = level instanceof ServerLevel &&
+                !this.linkFeedIfReady(level, LevelBEBroadcastLocation.of(this));
+    }
+
+    public static void tick(Level level, BlockPos pos, BlockState state, WaveGateBlockEntity tile) {
+        if (tile.linkDeferred) {
+            tile.linkDeferred = !tile.linkFeedIfReady(level, LevelBEBroadcastLocation.of(tile));
+        }
     }
 
     @Override


### PR DESCRIPTION
ViewFinderBlockEntity.setLevel() and WaveGateBlockEntity.setLevel() called BroadcastManager.getInstance() immediately, which NPEs on WorldSavedDataType.getData() when sub-level chunks are force-loaded from inside the ServerLevel constructor (e.g. Sable on server boot), because server.overworld() and its data storage are not available yet.

Linkings are now deferred: setLevel only links when the overworld and its data storage are bound (BroadcastManager.getInstanceIfReady) and retries from the block entity tick once the server is up.

Fixes #182 